### PR TITLE
Add hover to team member email address and edu organization

### DIFF
--- a/src/components/enrollment-form/team-form/member-card/index.tsx
+++ b/src/components/enrollment-form/team-form/member-card/index.tsx
@@ -8,50 +8,57 @@ interface IMemberCardProps {
   onSetCaptain: () => void
 }
 
-const MemberCard = ({ member, onDelete, onSetCaptain }: IMemberCardProps) => (
-  <li className="w-full bg-white shadow-sm rounded-lg pointer-events-auto flex ring-1 ring-black ring-opacity-5 divide-x divide-gray-200">
-    <div className="w-0 flex-1 flex items-center py-4 px-6">
-      <div className="flex-1 truncate">
-        <div className="flex items-center space-x-3">
-          <h3 className="text-gray-900 text-sm font-medium truncate">
-            {`${member.name.firstName} ${member.name.lastName}`}
-          </h3>
-          {member.isCaptain && (
-            <span className="flex-shrink-0 inline-block px-2 py-0.5 text-white text-xs font-medium bg-orange-500 rounded-full">
-              Captain
-            </span>
-          )}
+const MemberCard = ({ member, onDelete, onSetCaptain }: IMemberCardProps) => {
+  const subTitle = `${member.gender} (${member.birthYear}) - ${
+    member.emailAddress
+  } ${member.educationalInstitution && `- ${member.educationalInstitution}`}`
+
+  return (
+    <li className="w-full bg-white shadow-sm rounded-lg pointer-events-auto flex ring-1 ring-black ring-opacity-5 divide-x divide-gray-200">
+      <div className="w-0 flex-1 flex items-center py-4 px-6">
+        <div className="flex-1 truncate">
+          <div className="flex items-center space-x-3">
+            <h3 className="text-gray-900 text-sm font-medium truncate">
+              {`${member.name.firstName} ${member.name.lastName}`}
+            </h3>
+            {member.isCaptain && (
+              <span className="flex-shrink-0 inline-block px-2 py-0.5 text-white text-xs font-medium bg-orange-500 rounded-full">
+                Captain
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-gray-500 text-sm truncate" title={subTitle}>
+            {subTitle}
+          </p>
         </div>
-        <p className="mt-1 text-gray-500 text-sm truncate" title={`${member.emailAddress} - ${member.educationalInstitution}`}>
-          {`${member.gender} (${member.birthYear}) - ${member.emailAddress}`}
-        </p>
       </div>
-    </div>
-    <div className="flex">
-      <div className="flex flex-col divide-y divide-gray-200">
-        <div className="h-0 flex-1 flex">
-          <button
-            disabled={member.isCaptain}
-            onClick={() => onSetCaptain()}
-            className={`w-full border border-transparent rounded-none rounded-tr-lg px-4 py-3 flex items-center justify-center text-sm font-medium ${member.isCaptain
-              ? "cursor-default text-gray-300"
-              : "text-orange-500 hover:text-orange-400 focus:outline-none focus:z-10 focus:ring-2 focus:ring-orange-400"
+      <div className="flex">
+        <div className="flex flex-col divide-y divide-gray-200">
+          <div className="h-0 flex-1 flex">
+            <button
+              disabled={member.isCaptain}
+              onClick={() => onSetCaptain()}
+              className={`w-full border border-transparent rounded-none rounded-tr-lg px-4 py-3 flex items-center justify-center text-sm font-medium ${
+                member.isCaptain
+                  ? "cursor-default text-gray-300"
+                  : "text-orange-500 hover:text-orange-400 focus:outline-none focus:z-10 focus:ring-2 focus:ring-orange-400"
               }`}
-          >
-            Maak captain
-          </button>
-        </div>
-        <div className="h-0 flex-1 flex">
-          <button
-            className="w-full border border-transparent rounded-none rounded-br-lg px-4 py-3 flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-400"
-            onClick={() => onDelete()}
-          >
-            Verwijderen
-          </button>
+            >
+              Maak captain
+            </button>
+          </div>
+          <div className="h-0 flex-1 flex">
+            <button
+              className="w-full border border-transparent rounded-none rounded-br-lg px-4 py-3 flex items-center justify-center text-sm font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-400"
+              onClick={() => onDelete()}
+            >
+              Verwijderen
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-  </li>
-)
+    </li>
+  )
+}
 
 export default MemberCard

--- a/src/components/enrollment-form/team-form/member-card/index.tsx
+++ b/src/components/enrollment-form/team-form/member-card/index.tsx
@@ -22,7 +22,7 @@ const MemberCard = ({ member, onDelete, onSetCaptain }: IMemberCardProps) => (
             </span>
           )}
         </div>
-        <p className="mt-1 text-gray-500 text-sm truncate">
+        <p className="mt-1 text-gray-500 text-sm truncate" title={`${member.emailAddress} - ${member.educationalInstitution}`}>
           {`${member.gender} (${member.birthYear}) - ${member.emailAddress}`}
         </p>
       </div>
@@ -33,11 +33,10 @@ const MemberCard = ({ member, onDelete, onSetCaptain }: IMemberCardProps) => (
           <button
             disabled={member.isCaptain}
             onClick={() => onSetCaptain()}
-            className={`w-full border border-transparent rounded-none rounded-tr-lg px-4 py-3 flex items-center justify-center text-sm font-medium ${
-              member.isCaptain
-                ? "cursor-default text-gray-300"
-                : "text-orange-500 hover:text-orange-400 focus:outline-none focus:z-10 focus:ring-2 focus:ring-orange-400"
-            }`}
+            className={`w-full border border-transparent rounded-none rounded-tr-lg px-4 py-3 flex items-center justify-center text-sm font-medium ${member.isCaptain
+              ? "cursor-default text-gray-300"
+              : "text-orange-500 hover:text-orange-400 focus:outline-none focus:z-10 focus:ring-2 focus:ring-orange-400"
+              }`}
           >
             Maak captain
           </button>


### PR DESCRIPTION
If one of the team members has a long email-address it cannot be checked:
![image](https://user-images.githubusercontent.com/6750407/115110527-29bdd580-9f7c-11eb-9032-98a94c36b008.png)

By hovering over it you can now check it and you can also check the educational organization:
![image](https://user-images.githubusercontent.com/6750407/115110559-5a9e0a80-9f7c-11eb-8928-8a37cc983e7c.png)
