### PR TITLE
Limit team name length to 30 characters

### DIFF
--- a/src/components/enrollment-form/team-form/index.tsx
+++ b/src/components/enrollment-form/team-form/index.tsx
@@ -89,6 +89,7 @@ const TeamEnrollmentForm = ({
         error={errors?.teamName}
         {...register("teamName", {
           required: { value: true, message: "Dit veld is verplicht" },
+          maxLength: { value: 30, message: "Je teamnaam is te lang!" },
         })}
       />
       <div>


### PR DESCRIPTION
Has been limited in the backend as well.