### PR TITLE
Fix reload bug on delete / set captain

### DIFF
--- a/src/components/enrollment-form/individual-form/index.tsx
+++ b/src/components/enrollment-form/individual-form/index.tsx
@@ -43,7 +43,7 @@ const IndividualEnrollmentForm = ({
   }, [])
 
   return (
-    <form className="flex flex-col space-y-6">
+    <div className="flex flex-col space-y-6">
       {!isMemberForm && (
         <ContextCard
           mainText="Geen team? Geen nood!"
@@ -163,7 +163,7 @@ const IndividualEnrollmentForm = ({
           error={errors?.privacyStatement}
         />
       )}
-    </form>
+    </div>
   )
 }
 

--- a/src/components/enrollment-form/team-form/index.tsx
+++ b/src/components/enrollment-form/team-form/index.tsx
@@ -83,7 +83,7 @@ const TeamEnrollmentForm = ({
   }
 
   return (
-    <form className="flex flex-col space-y-6">
+    <div className="flex flex-col space-y-6">
       <Input
         label="Teamnaam*"
         error={errors?.teamName}
@@ -159,7 +159,7 @@ const TeamEnrollmentForm = ({
         }
         error={errors?.privacyStatement}
       />
-    </form>
+    </div>
   )
 }
 


### PR DESCRIPTION
Due to the usage of `<form>`, when clicking you will submit the form. But it has no action, so it won't do anything and just reloads. See: https://stackoverflow.com/a/58763330

To fix this, we just remove the `<form>` tag and replace it with `<div>`. The style of the page won't change and it won't cause this weird behavior.

@DiedB, can you check that this won't break registration? It shouldn't since the sign-up button is even outside of the `<form>` tag, but just to be sure :)